### PR TITLE
Upgrades datastore subcharts to latest from Bitnami

### DIFF
--- a/deployment/helm/Chart.lock
+++ b/deployment/helm/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 6.5.0
+  version: 11.7.6
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 9.4.3
-digest: sha256:370a0cefafd00e023a76d01a3a785252db4cd17fbf19f5ee4a3adcc282092d3a
-generated: "2020-05-29T12:28:49.817707+01:00"
+  version: 17.1.0
+digest: sha256:a7091d715e13b0f4acfe23586b4d541207d5c0cb4caa3d756342fb013d2213aa
+generated: "2022-08-22T10:04:45.764707-04:00"

--- a/deployment/helm/Chart.yaml
+++ b/deployment/helm/Chart.yaml
@@ -44,7 +44,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.5.0-beta
+version: 0.5.1-SNAPSHOT
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
@@ -52,8 +52,8 @@ appVersion: latest
 
 dependencies:
   - name: postgresql
-    version: 6.5.0
+    version: 11.7.6
     repository: "@bitnami"
   - name: redis
-    version: 9.4.3
+    version: 17.1.0
     repository: "@bitnami"

--- a/deployment/helm/templates/deployment.yaml
+++ b/deployment/helm/templates/deployment.yaml
@@ -59,8 +59,8 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: "{{ .Release.Name }}-postgresql"
-                key: postgresql-password
-          command: ["sh", "-c", "for i in {1..33}; do sleep 3; if PGPASSWORD=$POSTGRESQL_PASSWORD psql -h {{ .Release.Name }}-postgresql -U {{ .Values.postgresql.postgresqlUsername }}; then exit 0; fi; done; exit 1"]
+                key: password
+          command: ["sh", "-c", "for i in {1..33}; do sleep 3; if PGPASSWORD=$POSTGRESQL_PASSWORD psql -h {{ .Release.Name }}-postgresql -U {{ .Values.postgresql.auth.username }}; then exit 0; fi; done; exit 1"]
       containers:
         - name: {{ .Chart.Name }}
           env:
@@ -68,9 +68,9 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: "{{ .Release.Name }}-postgresql"
-                key: postgresql-password
+                key: password
           - name: DATABASE_URL
-            value: "postgres://{{ .Values.postgresql.postgresqlUsername }}:$(POSTGRESQL_PASSWORD)@{{ .Release.Name }}-postgresql"
+            value: "postgres://{{ .Values.postgresql.auth.username }}:$(POSTGRESQL_PASSWORD)@{{ .Release.Name }}-postgresql"
           - name: SECRET_KEY_BASE
             value: {{ include "postfacto.secretKey" . }}
           - name: DISABLE_SSL_REDIRECT


### PR DESCRIPTION
Thanks for contributing to postfacto. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

Updates Helm subchart references to use newer Bitnami Redis and Postgres charts

* An explanation of the use cases your change solves

Allows for using the latest version of the datastores available from Bitnami

* Links to any other associated PRs

* [X] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [X] I have made this pull request to the `master` branch

* [X] I have run all the tests using `./test.sh`.

* [X] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [X] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
